### PR TITLE
roc: update mtu and copy in RETA table

### DIFF
--- a/base/roc_nix.c
+++ b/base/roc_nix.c
@@ -476,7 +476,7 @@ skip_dev_init:
 	sdp_lbk_id_update(pci_dev, nix);
 	nix->pci_dev = pci_dev;
 	nix->reta_sz = reta_sz;
-	nix->mtu = ROC_NIX_DEFAULT_HW_FRS;
+	nix->mtu = roc_nix_max_pkt_len (roc_nix);
 	nix->dmac_flt_idx = -1;
 
 	/* Register error and ras interrupts */

--- a/base/roc_nix_rss.c
+++ b/base/roc_nix_rss.c
@@ -196,7 +196,7 @@ roc_nix_rss_reta_set(struct roc_nix *roc_nix, uint8_t group,
 	if (rc)
 		return rc;
 
-	memcpy(&nix->reta[group], reta, ROC_NIX_RSS_RETA_MAX);
+	memcpy(&nix->reta[group], reta, sizeof (uint16_t) * ROC_NIX_RSS_RETA_MAX);
 	return 0;
 }
 
@@ -209,7 +209,7 @@ roc_nix_rss_reta_get(struct roc_nix *roc_nix, uint8_t group,
 	if (group >= ROC_NIX_RSS_GRPS)
 		return NIX_ERR_PARAM;
 
-	memcpy(reta, &nix->reta[group], ROC_NIX_RSS_RETA_MAX);
+	memcpy(reta, &nix->reta[group], sizeof (uint16_t) * ROC_NIX_RSS_RETA_MAX);
 	return 0;
 }
 


### PR DESCRIPTION
This patch contains following changes
  -- updates queue entries copy in reta table
  based on data type
  -- sets MTU with max value for the port